### PR TITLE
Upgrade: switch to native Promise (fixes #32)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 
 node_js:
+  - "4"
+  - "3"
+  - "2"
+  - "1"
+  - "0.12"
   - "0.10"
 
 branches:

--- a/examples/custom_file_system.coffee
+++ b/examples/custom_file_system.coffee
@@ -1,4 +1,4 @@
-Promise = require 'bluebird'
+Promise = require 'native-or-bluebird'
 Liquid = require('../src')
 
 class CustomFileSystem extends Liquid.BlankFileSystem

--- a/package.json
+++ b/package.json
@@ -28,23 +28,21 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "native-or-bluebird": "~1.2.0",
     "strftime": "~0.8.0"
   },
-  "peerDependencies": {
-    "bluebird": "^2.1.3"
-  },
   "devDependencies": {
+    "bluebird": "~2.10.0",
     "chai": "~1.9.1",
     "chai-as-promised": "~4.1.1",
     "coffee-script": "~1.7.1",
     "coffeelint": "^1.5.2",
     "coveralls": "^2.10.1",
     "jscoverage": "^0.5.4",
-    "mocha": "~1.20.1",
+    "mocha": "~2.3.2",
     "mocha-lcov-reporter": "0.0.1",
     "sinon": "^1.10.2",
-    "sinon-chai": "^2.5.0",
-    "bluebird": "^2.3.10"
+    "sinon-chai": "^2.5.0"
   },
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register -R spec test",

--- a/src/liquid/blank_file_system.coffee
+++ b/src/liquid/blank_file_system.coffee
@@ -1,9 +1,8 @@
 Liquid = require "../liquid"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 module.exports = class Liquid.BlankFileSystem
   constructor: () ->
 
   readTemplateFile: (templatePath) ->
-    new Promise (resolve, reject) ->
-      reject new Liquid.FileSystemError "This file system doesn't allow includes"
+    Promise.reject new Liquid.FileSystemError "This file system doesn't allow includes"

--- a/src/liquid/block.coffee
+++ b/src/liquid/block.coffee
@@ -1,6 +1,6 @@
 Liquid = require("../liquid")
 util = require "util"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 module.exports = class Block extends Liquid.Tag
   @IsTag             = ///^#{Liquid.TagStart.source}///
@@ -19,10 +19,10 @@ module.exports = class Block extends Liquid.Tag
     @assertMissingDelimitation()
 
   parse: (tokens) ->
-    return Promise.cast() if tokens.length is 0 or @ended
+    return Promise.resolve() if tokens.length is 0 or @ended
     token = tokens.shift()
 
-    Promise.try =>
+    Promise.resolve().then =>
       @parseToken token, tokens
     .catch (e) ->
       e.message = "#{e.message}\n    at #{token.value} (#{token.filename}:#{token.line}:#{token.col})"
@@ -89,7 +89,7 @@ module.exports = class Block extends Liquid.Tag
         accumulator.push token
         return
 
-      Promise.try ->
+      Promise.resolve().then ->
         token.render context
       .then (s) ->
         accumulator.push s

--- a/src/liquid/condition.coffee
+++ b/src/liquid/condition.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../liquid"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 # Container for liquid nodes which conveniently wraps decision making logic
 #
@@ -32,10 +32,10 @@ module.exports = class Condition
 
     switch @childRelation
       when "or"
-        Promise.cast(result).then (result) =>
+        Promise.resolve(result).then (result) =>
           result or @childCondition.evaluate(context)
       when "and"
-        Promise.cast(result).then (result) =>
+        Promise.resolve(result).then (result) =>
           result and @childCondition.evaluate(context)
       else
         result
@@ -66,7 +66,7 @@ module.exports = class Condition
 
   resolveVariable: (v, context) ->
     if v of LITERALS
-      Promise.cast LITERALS[v]
+      Promise.resolve LITERALS[v]
     else
       context.get v
 

--- a/src/liquid/engine.coffee
+++ b/src/liquid/engine.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../liquid"
-Promise = require "bluebird"
 
 module.exports = class Liquid.Engine
 

--- a/src/liquid/iterable.coffee
+++ b/src/liquid/iterable.coffee
@@ -1,5 +1,5 @@
 Range = require "./range"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 isString = (input) ->
   Object::toString.call(input) is "[object String]"
@@ -41,7 +41,7 @@ class IterableForArray extends Iterable
   constructor: (@array) ->
 
   slice: ->
-    Promise.cast @array.slice arguments...
+    Promise.resolve @array.slice arguments...
 
   last: ->
-    Promise.cast @array[@array.length - 1]
+    Promise.resolve @array[@array.length - 1]

--- a/src/liquid/standard_filters.coffee
+++ b/src/liquid/standard_filters.coffee
@@ -1,5 +1,5 @@
 strftime = require "strftime"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 Iterable = require "./iterable"
 { flatten } = require "./helpers"
 
@@ -104,7 +104,7 @@ module.exports =
 
     toIterable(input)
     .map (item) ->
-      Promise.cast(item?[property])
+      Promise.resolve(item?[property])
       .then (key) ->
         { key, item }
     .then (array) ->

--- a/src/liquid/tag.coffee
+++ b/src/liquid/tag.coffee
@@ -1,4 +1,4 @@
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 module.exports = class Tag
   constructor: (@template, @tagName, @markup) ->
@@ -10,7 +10,7 @@ module.exports = class Tag
       parse = => @parse(args...)
 
     if @beforeParse
-      Promise.cast(@beforeParse(args...)).then parse
+      Promise.resolve(@beforeParse(args...)).then parse
     else
       parse()
 

--- a/src/liquid/tags/assign.coffee
+++ b/src/liquid/tags/assign.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../../liquid"
-Promise = require "bluebird"
 
 module.exports = class Assign extends Liquid.Tag
   SyntaxHelp = "Syntax Error in 'assign' - Valid syntax: assign [var] = [source]"

--- a/src/liquid/tags/case.coffee
+++ b/src/liquid/tags/case.coffee
@@ -1,5 +1,6 @@
 Liquid = require "../../liquid"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
+PromiseReduce = require "../../promise_reduce"
 
 module.exports = class Case extends Liquid.Block
   SyntaxHelp = "Syntax Error in tag 'case' - Valid syntax: case [expression]"
@@ -31,14 +32,14 @@ module.exports = class Case extends Liquid.Block
 
   render: (context) ->
     context.stack =>
-      Promise.reduce(@blocks, (chosenBlock, block) ->
+      PromiseReduce(@blocks, (chosenBlock, block) ->
         return chosenBlock if chosenBlock? # short-circuit
 
-        Promise
-        .try ->
-          block.evaluate context
-        .then (ok) ->
-          block if ok
+        Promise.resolve()
+          .then ->
+            block.evaluate context
+          .then (ok) ->
+            block if ok
       , null)
       .then (block) =>
         if block?

--- a/src/liquid/tags/if.coffee
+++ b/src/liquid/tags/if.coffee
@@ -1,5 +1,6 @@
 Liquid = require "../../liquid"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
+PromiseReduce = require "../../promise_reduce"
 
 module.exports = class If extends Liquid.Block
   SyntaxHelp = "Syntax Error in tag 'if' - Valid syntax: if [expression]"
@@ -34,15 +35,15 @@ module.exports = class If extends Liquid.Block
 
   render: (context) ->
     context.stack =>
-      Promise.reduce(@blocks, (chosenBlock, block) ->
+      PromiseReduce(@blocks, (chosenBlock, block) ->
         return chosenBlock if chosenBlock? # short-circuit
 
-        Promise
-        .try ->
-          block.evaluate context
-        .then (ok) ->
-          ok = !ok if block.negate
-          block if ok
+        Promise.resolve()
+          .then () ->
+            block.evaluate context
+          .then (ok) ->
+            ok = !ok if block.negate
+            block if ok
       , null)
       .then (block) =>
         if block?

--- a/src/liquid/tags/ifchanged.coffee
+++ b/src/liquid/tags/ifchanged.coffee
@@ -1,12 +1,12 @@
 Liquid = require "../../liquid"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 module.exports = class IfChanged extends Liquid.Block
   render: (context) ->
     context.stack =>
       rendered = @renderAll @nodelist, context
 
-      Promise.cast(rendered).then (output) ->
+      Promise.resolve(rendered).then (output) ->
         output = Liquid.Helpers.toFlatString output
 
         if output isnt context.registers.ifchanged

--- a/src/liquid/tags/raw.coffee
+++ b/src/liquid/tags/raw.coffee
@@ -1,10 +1,10 @@
 Liquid = require "../../liquid"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 module.exports = class Raw extends Liquid.Block
   parse: (tokens) ->
-    Promise.try =>
-      return Promise.cast() if tokens.length is 0 or @ended
+    Promise.resolve().then =>
+      return Promise.resolve() if tokens.length is 0 or @ended
 
       token = tokens.shift()
       match = Liquid.Block.FullToken.exec token.value

--- a/src/liquid/template.coffee
+++ b/src/liquid/template.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../liquid"
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 module.exports = class Liquid.Template
 
@@ -16,7 +16,7 @@ module.exports = class Liquid.Template
   # Parse source code.
   # Returns self for easy chaining
   parse: (@engine, source = "") ->
-    Promise.try =>
+    Promise.resolve().then =>
       tokens = @_tokenize source
 
       @tags = @engine.tags
@@ -37,7 +37,7 @@ module.exports = class Liquid.Template
   #    liquid more with its host application
   #
   render: (args...) ->
-    Promise.try => @_render args...
+    Promise.resolve().then => @_render args...
 
   _render: (assigns, options) ->
     throw new Error "No document root. Did you parse the document yet?" unless @root?

--- a/src/promise_reduce.coffee
+++ b/src/promise_reduce.coffee
@@ -1,0 +1,12 @@
+Promise = require "native-or-bluebird"
+
+
+reduce = (collection, reducer, value) ->
+  Promise.all(collection).then (items) ->
+    items.reduce (promise, item, index, length) ->
+      promise.then (value) ->
+        reducer(value, item, index, length)
+    , Promise.resolve(value)
+
+
+module.exports = reduce

--- a/test/_helper.coffee
+++ b/test/_helper.coffee
@@ -8,7 +8,7 @@ global.sinon = sinon = require "sinon"
 chai.use require "sinon-chai"
 
 global.expect = expect = chai.expect
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 # JSON.stringify fails for circular dependencies
 stringify = (v) ->

--- a/test/blocks.coffee
+++ b/test/blocks.coffee
@@ -1,5 +1,4 @@
 Liquid = requireLiquid()
-Promise = require "bluebird"
 
 describe "Blocks (in general)", ->
   beforeEach -> @engine = new Liquid.Engine

--- a/test/conditions.coffee
+++ b/test/conditions.coffee
@@ -1,5 +1,5 @@
 Liquid = requireLiquid()
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 describe "Liquid.Condition", ->
 

--- a/test/file_system.coffee
+++ b/test/file_system.coffee
@@ -1,5 +1,4 @@
 Liquid = requireLiquid()
-Promise = require "bluebird"
 Path = require "path"
 
 describe "Liquid.FileSystem", ->

--- a/test/filters.coffee
+++ b/test/filters.coffee
@@ -1,5 +1,5 @@
 Liquid = requireLiquid()
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 describe "StandardFilters", ->
   beforeEach ->
@@ -108,9 +108,9 @@ describe "StandardFilters", ->
 
     it "sorts on future properties", ->
       input = [
-        { count: Promise.cast(5) }
-        { count: Promise.cast(3) }
-        { count: Promise.cast(7) }
+        { count: Promise.resolve(5) }
+        { count: Promise.resolve(3) }
+        { count: Promise.resolve(7) }
       ]
 
       expect(@filters.sort(input, "count")).to.become [

--- a/test/futures.coffee
+++ b/test/futures.coffee
@@ -1,8 +1,8 @@
 Liquid = requireLiquid()
-Promise = require "bluebird"
+Promise = require "native-or-bluebird"
 
 asyncResult = (result) ->
-  Promise.cast(result).delay(1)
+  Promise.resolve(result).delay(1)
 
 describe "Futures", ->
   it "are supported as simple variables", ->


### PR DESCRIPTION
native-or-bluebird as dependency instead of bluebird as peerDependency

Comparing to bluebird, native `Promise` hasn't got methods like `Promise.try`, `Promise.reduce`. There was `Promise.cast` in bluebird but it's deprecated and removed for while now. Here's the equivalents:

```js
// Promise.cast(value)
Promise.resolve(value)

// Promise.try(fn)
Promise.resolve().then(fn)

// Promise.reduce(collection, reducer, initialValue)
Promise.all(collection).then(results) {
  return results.reduce(function(promise, item, index, length) {
    return promise.then(function(value) {
      return reducer(value, item, index, length)
    })
  }, initialValue)
})
```