### PR TITLE
Migrate from native-or-bluebird to any-promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,11 @@ env:
   global:
     - export COVERALLS_SERVICE_NAME=travis-ci
     - export COVERALLS_REPO_TOKEN=wEPmOB8VfKBdChU8hQ9tv9LfkeQHRl16D
-  matrix:
-    - PROMISES=native
-    - PROMISES=bluebird
 
 branches:
   only:
     - master
 
-before_install: ./scripts/before-install.sh
 script: ./scripts/run-tests.sh
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: node_js
 
 node_js:
+  - 8
+  - 6
   - 4
-  - 3
-  - 2
-  - 1
-  - 0.12
-  - "0.10"
 
 env:
   global:
@@ -25,8 +22,3 @@ script: ./scripts/run-tests.sh
 
 sudo: false
 
-matrix:
-  fast_finish: true
-  exclude:
-    - node_js: "0.10"
-      env: PROMISES=native

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 
 - Supports asynchronous variables, tags, functions and filters (helpers)
 - Allows you to add custom tags and filters easily
-- Uses [bluebird](https://github.com/petkaantonov/bluebird) for super-fast [Promises/A+](http://promisesaplus.com/)
 - Supports full liquid syntax
 - Based on original Ruby code
 - Written in CoffeeScript

--- a/examples/custom_file_system.coffee
+++ b/examples/custom_file_system.coffee
@@ -1,4 +1,4 @@
-Promise = require 'native-or-bluebird'
+Promise = require 'any-promise'
 Liquid = require('../src')
 
 class CustomFileSystem extends Liquid.BlankFileSystem

--- a/examples/custom_file_system.coffee
+++ b/examples/custom_file_system.coffee
@@ -1,4 +1,3 @@
-Promise = require 'any-promise'
 Liquid = require('../src')
 
 class CustomFileSystem extends Liquid.BlankFileSystem

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "main": "./lib/index.js",
   "engines": {
-    "node": ">= 0.10"
+    "node": ">=4"
   },
   "dependencies": {
     "strftime": "~0.9.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "native-or-bluebird": "~1.2.0",
+    "any-promise": "^1.3.0",
+    "es6-promise": "^4.1.0",
     "strftime": "~0.9.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "any-promise": "^1.3.0",
-    "es6-promise": "^4.1.0",
     "strftime": "~0.9.2"
   },
   "devDependencies": {

--- a/scripts/before-install.sh
+++ b/scripts/before-install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-if [ "${PROMISES}" = "bluebird" ]; then
-  npm install bluebird
-fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 npm test
 
-if [ "${TRAVIS_NODE_VERSION}" = "4" ] && [ "${PROMISES}" = "native" ]; then
+if [ "${TRAVIS_NODE_VERSION}" = "4" ] then
   npm run coverage
   npm run lint
 else

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 npm test
 
-if [ "${TRAVIS_NODE_VERSION}" = "4" ] then
+if [ "${TRAVIS_NODE_VERSION}" = "6" ] then
   npm run coverage
   npm run lint
 else

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 npm test
 
-if [ "${TRAVIS_NODE_VERSION}" = "6" ] then
+if [ "${TRAVIS_NODE_VERSION}" = "6" ]; then
   npm run coverage
   npm run lint
 else

--- a/src/liquid/blank_file_system.coffee
+++ b/src/liquid/blank_file_system.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 module.exports = class Liquid.BlankFileSystem
   constructor: () ->

--- a/src/liquid/blank_file_system.coffee
+++ b/src/liquid/blank_file_system.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../liquid"
-Promise = require "any-promise"
 
 module.exports = class Liquid.BlankFileSystem
   constructor: () ->

--- a/src/liquid/block.coffee
+++ b/src/liquid/block.coffee
@@ -1,6 +1,6 @@
 Liquid = require("../liquid")
 util = require "util"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 # Iterates over promises sequentially
 Promise_each = (promises, cb) ->

--- a/src/liquid/block.coffee
+++ b/src/liquid/block.coffee
@@ -1,6 +1,5 @@
 Liquid = require("../liquid")
 util = require "util"
-Promise = require "any-promise"
 
 # Iterates over promises sequentially
 Promise_each = (promises, cb) ->

--- a/src/liquid/condition.coffee
+++ b/src/liquid/condition.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 # Container for liquid nodes which conveniently wraps decision making logic
 #

--- a/src/liquid/condition.coffee
+++ b/src/liquid/condition.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../liquid"
-Promise = require "any-promise"
 
 # Container for liquid nodes which conveniently wraps decision making logic
 #

--- a/src/liquid/context.coffee
+++ b/src/liquid/context.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 module.exports = class Context
 

--- a/src/liquid/context.coffee
+++ b/src/liquid/context.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../liquid"
-Promise = require "any-promise"
 
 module.exports = class Context
 

--- a/src/liquid/iterable.coffee
+++ b/src/liquid/iterable.coffee
@@ -1,5 +1,4 @@
 Range = require "./range"
-Promise = require "any-promise"
 
 isString = (input) ->
   Object::toString.call(input) is "[object String]"

--- a/src/liquid/iterable.coffee
+++ b/src/liquid/iterable.coffee
@@ -1,5 +1,5 @@
 Range = require "./range"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 isString = (input) ->
   Object::toString.call(input) is "[object String]"

--- a/src/liquid/local_file_system.coffee
+++ b/src/liquid/local_file_system.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 Fs = require "fs"
 Path = require "path"
 

--- a/src/liquid/local_file_system.coffee
+++ b/src/liquid/local_file_system.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../liquid"
-Promise = require "any-promise"
 Fs = require "fs"
 Path = require "path"
 

--- a/src/liquid/standard_filters.coffee
+++ b/src/liquid/standard_filters.coffee
@@ -1,5 +1,4 @@
 strftime = require "strftime"
-Promise = require "any-promise"
 Iterable = require "./iterable"
 { flatten } = require "./helpers"
 

--- a/src/liquid/standard_filters.coffee
+++ b/src/liquid/standard_filters.coffee
@@ -1,5 +1,5 @@
 strftime = require "strftime"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 Iterable = require "./iterable"
 { flatten } = require "./helpers"
 

--- a/src/liquid/tag.coffee
+++ b/src/liquid/tag.coffee
@@ -1,4 +1,4 @@
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 module.exports = class Tag
   constructor: (@template, @tagName, @markup) ->

--- a/src/liquid/tag.coffee
+++ b/src/liquid/tag.coffee
@@ -1,5 +1,3 @@
-Promise = require "any-promise"
-
 module.exports = class Tag
   constructor: (@template, @tagName, @markup) ->
 

--- a/src/liquid/tags/case.coffee
+++ b/src/liquid/tags/case.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../../liquid"
-Promise = require "any-promise"
 PromiseReduce = require "../../promise_reduce"
 
 module.exports = class Case extends Liquid.Block

--- a/src/liquid/tags/case.coffee
+++ b/src/liquid/tags/case.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 PromiseReduce = require "../../promise_reduce"
 
 module.exports = class Case extends Liquid.Block

--- a/src/liquid/tags/for.coffee
+++ b/src/liquid/tags/for.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../../liquid"
-Promise = require "any-promise"
 PromiseReduce = require "../../promise_reduce"
 Iterable = require "../iterable"
 

--- a/src/liquid/tags/for.coffee
+++ b/src/liquid/tags/for.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 PromiseReduce = require "../../promise_reduce"
 Iterable = require "../iterable"
 

--- a/src/liquid/tags/if.coffee
+++ b/src/liquid/tags/if.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 PromiseReduce = require "../../promise_reduce"
 
 module.exports = class If extends Liquid.Block

--- a/src/liquid/tags/if.coffee
+++ b/src/liquid/tags/if.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../../liquid"
-Promise = require "any-promise"
 PromiseReduce = require "../../promise_reduce"
 
 module.exports = class If extends Liquid.Block

--- a/src/liquid/tags/ifchanged.coffee
+++ b/src/liquid/tags/ifchanged.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../../liquid"
-Promise = require "any-promise"
 
 module.exports = class IfChanged extends Liquid.Block
   render: (context) ->

--- a/src/liquid/tags/ifchanged.coffee
+++ b/src/liquid/tags/ifchanged.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 module.exports = class IfChanged extends Liquid.Block
   render: (context) ->

--- a/src/liquid/tags/raw.coffee
+++ b/src/liquid/tags/raw.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../../liquid"
-Promise = require "any-promise"
 
 module.exports = class Raw extends Liquid.Block
   parse: (tokens) ->

--- a/src/liquid/tags/raw.coffee
+++ b/src/liquid/tags/raw.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 module.exports = class Raw extends Liquid.Block
   parse: (tokens) ->

--- a/src/liquid/template.coffee
+++ b/src/liquid/template.coffee
@@ -1,5 +1,5 @@
 Liquid = require "../liquid"
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 module.exports = class Liquid.Template
 

--- a/src/liquid/template.coffee
+++ b/src/liquid/template.coffee
@@ -1,5 +1,4 @@
 Liquid = require "../liquid"
-Promise = require "any-promise"
 
 module.exports = class Liquid.Template
 

--- a/src/liquid/variable.coffee
+++ b/src/liquid/variable.coffee
@@ -1,5 +1,4 @@
 Liquid = require("../liquid")
-Promise = require "any-promise"
 PromiseReduce = require "../promise_reduce"
 
 # Holds variables. Variables are only loaded "just in time"

--- a/src/liquid/variable.coffee
+++ b/src/liquid/variable.coffee
@@ -1,5 +1,5 @@
 Liquid = require("../liquid")
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 PromiseReduce = require "../promise_reduce"
 
 # Holds variables. Variables are only loaded "just in time"

--- a/src/promise_reduce.coffee
+++ b/src/promise_reduce.coffee
@@ -1,4 +1,4 @@
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 
 reduce = (collection, reducer, value) ->

--- a/src/promise_reduce.coffee
+++ b/src/promise_reduce.coffee
@@ -1,5 +1,3 @@
-Promise = require "any-promise"
-
 
 reduce = (collection, reducer, value) ->
   Promise.all(collection).then (items) ->

--- a/test/_helper.coffee
+++ b/test/_helper.coffee
@@ -8,7 +8,6 @@ global.sinon = sinon = require "sinon"
 chai.use require "sinon-chai"
 
 global.expect = expect = chai.expect
-Promise = require "any-promise"
 
 # JSON.stringify fails for circular dependencies
 stringify = (v) ->

--- a/test/_helper.coffee
+++ b/test/_helper.coffee
@@ -8,7 +8,7 @@ global.sinon = sinon = require "sinon"
 chai.use require "sinon-chai"
 
 global.expect = expect = chai.expect
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 # JSON.stringify fails for circular dependencies
 stringify = (v) ->

--- a/test/conditions.coffee
+++ b/test/conditions.coffee
@@ -1,5 +1,5 @@
 Liquid = requireLiquid()
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 describe "Liquid.Condition", ->
 

--- a/test/conditions.coffee
+++ b/test/conditions.coffee
@@ -1,5 +1,4 @@
 Liquid = requireLiquid()
-Promise = require "any-promise"
 
 describe "Liquid.Condition", ->
 

--- a/test/filters.coffee
+++ b/test/filters.coffee
@@ -1,5 +1,4 @@
 Liquid = requireLiquid()
-Promise = require "any-promise"
 strftime = require "strftime"
 
 describe "StandardFilters", ->

--- a/test/filters.coffee
+++ b/test/filters.coffee
@@ -1,5 +1,5 @@
 Liquid = requireLiquid()
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 strftime = require "strftime"
 
 describe "StandardFilters", ->

--- a/test/futures.coffee
+++ b/test/futures.coffee
@@ -1,5 +1,5 @@
 Liquid = requireLiquid()
-Promise = require "native-or-bluebird"
+Promise = require "any-promise"
 
 asyncResult = (result, delay = 1) ->
   new Promise (resolve) ->

--- a/test/futures.coffee
+++ b/test/futures.coffee
@@ -1,5 +1,4 @@
 Liquid = requireLiquid()
-Promise = require "any-promise"
 
 asyncResult = (result, delay = 1) ->
   new Promise (resolve) ->


### PR DESCRIPTION
We’re seeing a deprecation message on our project when installing:

```shell
$ npm install
# ...
npm WARN deprecated native-or-bluebird@1.2.0: 'native-or-bluebird' is deprecated. Please use 'any-promise' instead.
# ...
```

This comes from liquid-node:

```shell
$ npm ls native-or-bluebird@1.2.0
# ...
└─┬ liquid-node@2.6.1
  └── native-or-bluebird@1.2.0 
```

native-or-bluebird [has been deprecated for a while](https://github.com/normalize/native-or-bluebird/commit/497cb2a50dba2dd1c417457424f14b6b7b03fb34). The former maintainers recommend [any-promise](https://github.com/kevinbeaty/any-promise).

This PR changes `native-or-bluebird` calls to `any-promise`, which [checks for global `Promise`](https://github.com/kevinbeaty/any-promise/blob/c2029f9e37a15b04c303bd0ec19cf16d00ec8f3d/register.js#L47-L64) and [falls back to popular implementations](https://github.com/kevinbeaty/any-promise/blob/c2029f9e37a15b04c303bd0ec19cf16d00ec8f3d/register.js#L66-L94) for older versions of Node.js. `es6-promise` is used in place of `bluebird` as it’s significantly smaller download.

`npm test` on both Node.js 6.11.0 and v0.10.48 works :+1: